### PR TITLE
2016-09 big sync from bitbucket

### DIFF
--- a/manifests/central.pp
+++ b/manifests/central.pp
@@ -51,9 +51,10 @@ class rsyslog::central (
   }
 
   file { $datadir :
-    ensure => directory,
-    owner  => $user,
-    group  => $group,
+    ensure  => directory,
+    owner   => $user,
+    group   => $group,
+    seltype => 'var_log_t',
   }
 
   file { "/etc/init.d/${service}" :

--- a/templates/central.conf.erb
+++ b/templates/central.conf.erb
@@ -46,12 +46,12 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 $RepeatedMsgReduction on
 
 # log destinations
-$template RemoteMessages, "/data/syslog/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/messages"
-$template RemoteSecure,   "/data/syslog/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/secure"
-$template RemoteMaillog,  "/data/syslog/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/maillog"
-$template RemoteCron,     "/data/syslog/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/cron"
-$template RemoteSpooler,  "/data/syslog/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/spooler"
-$template RemoteDaemon,   "/data/syslog/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/spooler"
+$template RemoteMessages, "<%= @datadir %>/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/messages"
+$template RemoteSecure,   "<%= @datadir %>/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/secure"
+$template RemoteMaillog,  "<%= @datadir %>/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/maillog"
+$template RemoteCron,     "<%= @datadir %>/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/cron"
+$template RemoteSpooler,  "<%= @datadir %>/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/spooler"
+$template RemoteDaemon,   "<%= @datadir %>/%HOSTNAME%/%$YEAR%%$MONTH%%$DAY%/spooler"
 
 # log rules
 


### PR DESCRIPTION
Sets `seltype` on dir, useful if central syslog is running `SELinux` enabled. Otherwise, service won't log properly.

Also, uses `datadir` variable in template instead of hardcoded value. _Note_: To make it compatible with current setup set `rsyslog::central::datadir` to `/data/syslog` in hiera.
